### PR TITLE
refactor: consolidate log file collection logic

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -327,7 +327,6 @@ fn handle_routine_load_loop(config: &Config, tools: &[Box<dyn Tool>]) -> Result<
     }
 }
 
-/// 执行 Routine Load 工具的辅助函数
 fn execute_routine_load_tool(
     config: &Config,
     tools: &[Box<dyn Tool>],

--- a/src/tools/fe/routine_load/log_parser.rs
+++ b/src/tools/fe/routine_load/log_parser.rs
@@ -3,7 +3,7 @@ use chrono::NaiveDateTime;
 use regex::Regex;
 use std::fs;
 use std::io::{BufRead, BufReader};
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 #[derive(Debug, Clone, Default)]
 pub struct LogCommitEntry {
@@ -64,47 +64,6 @@ impl FeLogParser {
 
         Some(entry)
     }
-}
-
-pub fn collect_fe_logs(dir: &Path) -> Result<Vec<PathBuf>> {
-    if !dir.exists() {
-        return Err(CliError::ConfigError(format!(
-            "Log directory does not exist: {}",
-            dir.display()
-        )));
-    }
-
-    if !dir.is_dir() {
-        return Err(CliError::ConfigError(format!(
-            "Path is not a directory: {}",
-            dir.display()
-        )));
-    }
-
-    let mut files: Vec<PathBuf> = fs::read_dir(dir)
-        .map_err(CliError::IoError)?
-        .filter_map(|e| e.ok())
-        .map(|e| e.path())
-        .filter(|p| {
-            p.file_name()
-                .and_then(|n| n.to_str())
-                .map(|s| s.starts_with("fe.log"))
-                .unwrap_or(false)
-        })
-        .collect();
-
-    if files.is_empty() {
-        return Err(CliError::ConfigError(format!(
-            "No fe.log files found in directory: {}",
-            dir.display()
-        )));
-    }
-
-    // Sort by modification time (newest first)
-    files.sort_by_key(|p| fs::metadata(p).and_then(|m| m.modified()).ok());
-    files.reverse();
-
-    Ok(files)
 }
 
 pub fn scan_file(

--- a/src/tools/fe/routine_load/performance_analyzer.rs
+++ b/src/tools/fe/routine_load/performance_analyzer.rs
@@ -1,13 +1,15 @@
+use chrono::Duration;
+use std::collections::HashMap;
+
 use super::job_manager::RoutineLoadJobManager;
-use super::log_parser::{FeLogParser, LogCommitEntry, collect_fe_logs, scan_file};
+use super::log_parser::{FeLogParser, LogCommitEntry, scan_file};
 use crate::config::Config;
 use crate::error::{CliError, Result};
+use crate::tools::common::fs_utils;
 use crate::tools::fe::routine_load::messages as ErrMsg;
 use crate::tools::{ExecutionResult, Tool};
 use crate::ui;
 use crate::ui::{FormatHelper, InputHelper};
-use chrono::Duration;
-use std::collections::HashMap;
 
 pub struct RoutineLoadPerformanceAnalyzer;
 
@@ -65,7 +67,7 @@ impl RoutineLoadPerformanceAnalyzer {
         log_dir: &std::path::Path,
         job_id: &str,
     ) -> Result<Vec<LogCommitEntry>> {
-        let files = collect_fe_logs(log_dir)?;
+        let files = fs_utils::collect_fe_logs(log_dir)?;
         let parser = FeLogParser::new();
         let mut entries: Vec<LogCommitEntry> = Vec::new();
 

--- a/src/tools/fe/routine_load/traffic_monitor.rs
+++ b/src/tools/fe/routine_load/traffic_monitor.rs
@@ -1,13 +1,15 @@
+use chrono::Duration;
+use std::collections::BTreeMap;
+
 use super::job_manager::RoutineLoadJobManager;
-use super::log_parser::{FeLogParser, LogCommitEntry, collect_fe_logs, scan_file};
+use super::log_parser::{FeLogParser, LogCommitEntry, scan_file};
 use crate::config::Config;
 use crate::error::{CliError, Result};
+use crate::tools::common::fs_utils;
 use crate::tools::fe::routine_load::messages as ErrMsg;
 use crate::tools::{ExecutionResult, Tool};
 use crate::ui;
 use crate::ui::InputHelper;
-use chrono::Duration;
-use std::collections::BTreeMap;
 
 pub struct RoutineLoadTrafficMonitor;
 
@@ -72,7 +74,7 @@ impl RoutineLoadTrafficMonitor {
         log_dir: &std::path::Path,
         job_id: &str,
     ) -> Result<Vec<LogCommitEntry>> {
-        let files = collect_fe_logs(log_dir)?;
+        let files = fs_utils::collect_fe_logs(log_dir)?;
         let parser = FeLogParser::new();
         let mut entries: Vec<LogCommitEntry> = Vec::new();
 

--- a/src/ui/menu.rs
+++ b/src/ui/menu.rs
@@ -194,7 +194,7 @@ pub fn show_fe_tools_menu() -> Result<FeToolAction> {
             MenuOption {
                 action: FeToolAction::RoutineLoad,
                 key: "[5]".to_string(),
-                name: "Routine Load".to_string(),
+                name: "routine-load".to_string(),
                 description: "Routine Load management tools".to_string(),
             },
             MenuOption {


### PR DESCRIPTION
## Bug Behavior

```bash
Step 3 Routine Load Tools
[i]  Executing routine_load_performance_analyzer...
Analyze recent minutes: 50
[i]  Analyzing FE logs in /opt/selectdb/fe/log for job 667132769802263 (last 50 min)...
[i]
[*]  Tool execution failed due to configuration issues.
[!]  Error: IO error: stream did not contain valid UTF-8
[i]
```

## What Cause?

Because in the fe/log directory, there are some files like fe.log.tar.gz, we need to filter them.